### PR TITLE
builds without cam_deser_4_to_pixels.vhd

### DIFF
--- a/hw/logipi/ise/logipi_mt9v034.xise
+++ b/hw/logipi/ise/logipi_mt9v034.xise
@@ -75,10 +75,6 @@
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="66"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="19"/>
     </file>
-    <file xil_pn:name="../../../../logi-hard/hdl/control/cam_deser_4_to_pixels.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="67"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
-    </file>
     <file xil_pn:name="../../../../logi-hard/hdl/control/cam_deser_4_to_pixels_v2.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="68"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="16"/>


### PR DESCRIPTION
using cam_deser_4_to_pixels_v2.vhd
